### PR TITLE
new: global docker-compose is working

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+version: "3.8"
+services:
+  db_dojo:
+    image: rxinui/db_dojo:latest
+    build:
+      context: ./services/db_dojo/
+    ports:
+      - 3306:3306
+    networks:
+      intdojonet:
+        ipv4_address: 172.20.0.1
+  rabbitmq:
+    image: rxinui/rabbitmq:latest
+    build:
+      context: services/rabbitmq/
+    ports:
+      - 5672:5672
+    networks:
+      intdojonet:
+        ipv4_address: 172.20.0.2
+  api_auth:
+    image: rxinui/api_auth:latest
+    build:
+      context: ./services/api_auth/
+    ports:
+      - 8000:80
+    networks:
+      intdojonet:
+        ipv4_address: 172.20.0.11
+  api_vbox:
+    image: rxinui/api_vbox:latest
+    build:
+      context: ./services/api_vbox/
+    ports:
+      - 8001:80
+    networks:
+      intdojonet:
+        ipv4_address: 172.20.0.12
+networks:
+  intdojonet:
+    name: intdojonet
+    ipam:
+      driver: bridge
+      config:
+       - subnet: "172.20.0.0/27" # API global internal network - dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,33 +6,57 @@ services:
       context: ./services/db_dojo/
     ports:
       - 3306:3306
+    environment:
+      MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: oui
+      MARIADB_USER: sifu
+      MARIADB_PASSWORD: sifu
+      MARIADB_DATABASE: dojo
     networks:
       intdojonet:
-        ipv4_address: 172.20.0.1
+        ipv4_address: 172.20.0.2
   rabbitmq:
-    image: rxinui/rabbitmq:latest
-    build:
-      context: services/rabbitmq/
+    image: rabbitmq:3.9.13
     ports:
       - 5672:5672
     networks:
       intdojonet:
-        ipv4_address: 172.20.0.2
+        ipv4_address: 172.20.0.3
   api_auth:
+    depends_on:
+      - db_dojo
     image: rxinui/api_auth:latest
     build:
       context: ./services/api_auth/
     ports:
       - 8000:80
+    environment:
+      API_AUTH_HOST: 172.20.0.11
+      API_AUTH_PORT: 80
+      API_DB_HOST: 172.20.0.2
+      API_DB_USER: sifu
+      API_DB_PASSWORD: sifu
+      API_DB_DATABASE: dojo
+      API_DB_CONNECTION_LIMIT: 10
+    
     networks:
       intdojonet:
         ipv4_address: 172.20.0.11
   api_vbox:
+    depends_on:
+      - db_dojo
+      - rabbitmq
     image: rxinui/api_vbox:latest
     build:
       context: ./services/api_vbox/
     ports:
       - 8001:80
+    environment:
+      API_VBOX_HOST: 172.20.0.12
+      API_VBOX_PORT: 80
+      API_VBOX_EXECMODE: container
+      API_VBOX_RABBITMQ_HOST: 172.20.0.3
+      API_VBOX_RABBITMQ_PORT: 5672
+      API_VBOX_USERS_REQUEST_QUEUE: api_vbox.users.request_queue
     networks:
       intdojonet:
         ipv4_address: 172.20.0.12
@@ -40,6 +64,6 @@ networks:
   intdojonet:
     name: intdojonet
     ipam:
-      driver: bridge
+      driver: default
       config:
-       - subnet: "172.20.0.0/27" # API global internal network - dev
+        - subnet: "172.20.0.0/26" # API global internal network - dev

--- a/services/api_auth/.dockerignore
+++ b/services/api_auth/.dockerignore
@@ -1,0 +1,2 @@
+node_modules/
+npm-debug.log

--- a/services/api_auth/Dockerfile
+++ b/services/api_auth/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:16
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+RUN npm install
+# If you are building your code for production
+# RUN npm ci --only=production
+
+# Bundle app source
+COPY . .
+
+EXPOSE 8000
+CMD [ "npm", "start" ]

--- a/services/api_auth/README.dev.md
+++ b/services/api_auth/README.dev.md
@@ -17,10 +17,11 @@ npm i
 Create a `.env` file
 
 ```shell
-API_HOST_URL="http://localhost:3000"
+API_AUTH_HOST="localhost"
+API_AUTH_PORT="80"
 API_DB_HOST="0.0.0.0"
-API_DB_USER="root"
-API_DB_PASSWORD="root"
+API_DB_USER="sifu"
+API_DB_PASSWORD="sifu"
 API_DB_DATABASE="dojo"
 API_DB_CONNECTION_LIMIT=10
 ```

--- a/services/api_auth/docker-compose.yml
+++ b/services/api_auth/docker-compose.yml
@@ -1,0 +1,39 @@
+version: '3.8'
+
+services:
+
+  db:
+    image: rxinui/db_dojo:latest
+    ports:
+      - 3306:3306
+    volumes:
+      - "../db_dojo/volume/initdb.d/:/docker-entrypoint-initdb.d/"
+    restart: always
+    environment:
+      MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: oui
+      MARIADB_USER: sifu
+      MARIADB_PASSWORD: sifu
+      MARIADB_DATABASE: dojo
+    networks:
+      devnet:
+        ipv4_address: 172.20.0.101
+
+  api_auth:
+    depends_on: 
+    - db
+    image: rxinui/api_auth:latest
+    build:
+      context: ./
+    ports:
+      - 8000:${API_AUTH_PORT}
+    environment:
+      API_DB_HOST: "172.20.0.101"
+    networks:
+      devnet:
+        ipv4_address: 172.20.0.102
+networks:
+  devnet:
+    ipam:
+      driver: default
+      config:
+        - subnet: "172.20.0.0/24" # API global internal network - dev

--- a/services/api_auth/server.js
+++ b/services/api_auth/server.js
@@ -1,11 +1,16 @@
 require("dotenv").config();
 const express = require('express')
 const routeUser = require('./routes/user')
-const port = 3000
+const port = process.env.API_AUTH_PORT || 3000
+const host = process.env.API_AUTH_HOST || "localhost"
 const app = express()
 
-app.use('/user/',routeUser)
+app.use('/user/', routeUser)
+
+app.get("/", async (request, reply) => {
+    reply.send("Hello on api_auth!")
+})
 
 app.listen(port, () => {
-    console.log(`> Go to the dojo http://localhost:${port}`)
+    console.log(`> Go to the dojo http://${host}:${port}`)
 })

--- a/services/api_auth/test/test_user.js
+++ b/services/api_auth/test/test_user.js
@@ -4,7 +4,7 @@ var expect = require('expect.js')
 require("dotenv").config();
 
 const api = require('axios').create({
-    baseURL: process.env.API_HOST_URL,
+    baseURL: `http://${process.env.API_AUTH_HOST}:${process.env.API_AUTH_PORT}`,
     timeout: 1000,
     headers: { "Content-Type": "application/json" }
 })

--- a/services/api_vbox/Dockerfile
+++ b/services/api_vbox/Dockerfile
@@ -8,5 +8,9 @@ RUN python -m pip install pip --upgrade && \
 
 ENV API_VBOX_HOST 0.0.0.0
 ENV API_VBOX_PORT 80
+ENV API_VBOX_EXECMODE="local"
+ENV API_VBOX_RABBITMQ_HOST="0.0.0.0"
+ENV API_VBOX_RABBITMQ_PORT="5672"
+ENV API_VBOX_USERS_REQUEST_QUEUE="api_vbox.users.request_queue"
 
 CMD ["bash","-c", "uvicorn main:app --port $API_VBOX_PORT --host $API_VBOX_HOST"]

--- a/services/api_vbox/docker-compose.yml
+++ b/services/api_vbox/docker-compose.yml
@@ -6,7 +6,11 @@ services:
       context: .
     environment:
       API_VBOX_HOST: 0.0.0.0
-      API_VBOX_PORT: 8080
+      API_VBOX_PORT: 80
+      API_VBOX_EXECMODE: "container"
+      API_VBOX_RABBITMQ_HOST: "0.0.0.0"
+      API_VBOX_RABBITMQ_PORT: "5672"
+      API_VBOX_USERS_REQUEST_QUEUE: "api_vbox.users.request_queue"
     ports:
       - 9000:8080
     

--- a/services/api_vbox/requirements.txt
+++ b/services/api_vbox/requirements.txt
@@ -5,3 +5,4 @@ python-jose[cryptography]
 passlib[bcrypt]
 requests
 python-dotenv
+pika


### PR DESCRIPTION
[PFE-24]
- new: services/api_auth docker-compose is working
- ref: api_auth adjustment to make it work with docker-compose
- tests are ok for api_auth/ when docker-compose is up
- manual test on api_vbox and rabbitmq ok when rabbitmq_server is up

[PFE-24]: https://kidr.atlassian.net/browse/PFE-24?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ