### PR TITLE
new: CD workflow to deploy github project

### DIFF
--- a/.github/workflows/call_ci_services.yml
+++ b/.github/workflows/call_ci_services.yml
@@ -6,12 +6,9 @@
 # --> [Test unit tests of the service]
 # --> <Build and push as Docker image>
 
-name: Continuous integration of services into Docker Image
+name: "[Reusable] Continuous integration of services into Docker Image"
 on:
-  push:
-    branches: [main, develop]
-  pull_request:
-    branches: [main, develop]
+  workflow_call:
 env:
   DB_DOJO_VERSION: 0.1.1
   API_AUTH_VERSION: 0.1.1

--- a/.github/workflows/call_deploy_ssh.yml
+++ b/.github/workflows/call_deploy_ssh.yml
@@ -1,0 +1,35 @@
+# CD services aims to deploy all services Docker image to (pre-)prod
+# Logicial view of the CD is :
+#
+#
+
+name: "[Reusable] Continuous deployment of services with Git through SSH"
+on:
+  workflow_call:
+    inputs:
+      deploy-branch:
+        required: true
+        default: develop
+        type: string
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    name: Deploy project
+    steps:
+      - name: Use of Rxinui/ssh-deploy-repo-action to deploy
+        uses: Rxinui/ssh-deploy-repo-action@v1.1
+        with:
+          ssh-user: ubuntu
+          ssh-password: ${{ secrets.OVH_ns343000_PASSWORD }}
+          ssh-domain: ${{ secrets.OVH_ns343000_DOMAIN }}
+          git-clone-by: ssh
+          target-branch: ${{ inputs.deploy-branch }}
+          target-directory: /opt/pfe/DojoPlateforme
+          pre-command: |
+            cd /opt/pfe/DojoPlateforme &&
+            docker-compose down -v --remove-orphans
+          post-command: docker-compose up --build -d
+            
+
+
+  

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+name: Simple CI/CD to remote host (Pre-prod)
+on:
+  push:
+    branches: [main, develop, pfe48_cd_deploy]
+  pull_request:
+    branches: [main, develop]
+jobs:
+  call-ci-services:
+    uses: ./.github/workflows/call_ci_services.yml
+    secrets: inherit
+  call-deploy:
+    needs: call-ci-services
+    uses: ./.github/workflows/call_deploy_ssh.yml
+    with:
+      deploy-branch: pfe48_cd_deploy
+    secrets: inherit
+  

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - 3306:3306
     environment:
-      MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: oui
+      - MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=yes
     networks:
       intdojonet:
         ipv4_address: 172.20.0.2
@@ -49,15 +49,15 @@ services:
     ports:
       - 8000:80
     environment:
-      API_AUTH_HOST: 172.20.0.10
-      API_AUTH_PORT: 80
-      API_AUTH_SESSION_SECRET: "bhkKyq8yEaHd49PD"
-      API_AUTH_JWT_SECRET: "q@M&P8gXLJrh47&d"
-      API_DB_HOST: 172.20.0.2
-      API_DB_USER: sifu
-      API_DB_PASSWORD: sifu
-      API_DB_DATABASE: dojo_auth
-      API_DB_CONNECTION_LIMIT: 10
+      - API_AUTH_HOST=172.20.0.10
+      - API_AUTH_PORT=80
+      - API_AUTH_SESSION_SECRET="bhkKyq8yEaHd49PD"
+      - API_AUTH_JWT_SECRET="q@M&P8gXLJrh47&d"
+      - API_DB_HOST=172.20.0.2
+      - API_DB_USER=sifu
+      - API_DB_PASSWORD=sifu
+      - API_DB_DATABASE=dojo_auth
+      - API_DB_CONNECTION_LIMIT=10
 
     networks:
       intdojonet:
@@ -72,13 +72,16 @@ services:
     ports:
       - 8001:80
     environment:
-      API_VBOX_HOST: 172.20.0.11
-      API_VBOX_PORT: 80
-      API_VBOX_EXECMODE: container
-      API_VBOX_RABBITMQ_HOST: 172.20.0.30
-      API_VBOX_RABBITMQ_PORT: 5672
-      API_VBOX_USERS_REQUEST_QUEUE: api_vbox.users.request_queue
-      API_AUTH_URL: http://172.20.0.10
+      - API_VBOX_HOST=172.20.0.11
+      - API_VBOX_PORT=80
+      - API_VBOX_EXECMODE=container
+      - STORAGE_VMS_BASEFOLDER="/var/opt/DojoPlateforme/vms/"
+      - STORAGE_OVF_BASEFOLDER="/usr/share/DojoPlateforme/ovf/"
+      - API_VBOX_RABBITMQ_HOST=172.20.0.30
+      - API_VBOX_RABBITMQ_PORT=5672
+      - API_VBOX_USERS_REQUEST_QUEUE=api_vbox.users.request_queue
+      - API_AUTH_URL=http://172.20.0.10
+      - APP_ENVIRONMENT=dev
     networks:
       intdojonet:
         ipv4_address: 172.20.0.11


### PR DESCRIPTION
[PFE-48]
- new: use of personal action Rxinui/ssh-deploy-repo-action
to deploy the project
- ref: updated according to ssh-deploy-repo-action changes
- add pre-command value to use docker-compose down
- add post-command value to use docker-compose up
- fix: update global docker-compose to fix api_vbox
- ref: new workflow and reusable workflow

[PFE-48]: https://kidr.atlassian.net/browse/PFE-48?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ